### PR TITLE
fix: broken markup

### DIFF
--- a/docs/devbox/faq/index.mdx
+++ b/docs/devbox/faq/index.mdx
@@ -128,13 +128,13 @@ disable this behavior by setting this environment variable in your shell's rcfil
 
 ```bash
 DEVBOX_NO_PROMPT=true
-```json
+```
 
 If you are using Fish:
 
-```
+```fish
 set -U devbox_no_prompt true
-```bash
+```
 
 ## How can I uninstall Devbox?[​](#how-can-i-uninstall-devbox "Direct link to How can I uninstall Devbox?")
 


### PR DESCRIPTION
Somehow the code block markup on the FAQ page was messed up.
This PR fixes that.