### PR TITLE
Fix info admonition

### DIFF
--- a/docs/testpilot/guides/parallel-testing.mdx
+++ b/docs/testpilot/guides/parallel-testing.mdx
@@ -9,7 +9,7 @@ description: "Speed up test execution by running tests in parallel. Configure co
 When you set `--concurrency N`, Testpilot keeps up to N test files in flight on that machine. If you
 omit the flag, we apply a sensible default of 10.
 
-::: info Mobile tests are automatically forced to `1` because simulators/devices do not support
+:::info Mobile tests are automatically forced to `1` because simulators/devices do not support
 running multiple tests or instances of an application concurrently. Future releases will introduce
 the option to pass multiple devices to run mobile tests in parallel. :::
 


### PR DESCRIPTION
This PR removes the extra ` ` that causes the admonition not to render properly. It resolves #23.